### PR TITLE
Downgrade Language Level for Java 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+gradlew
+gradlew.bat
+build
+.idea
+.gradle
+gradle

--- a/src/main/java/net/andreinc/neatchess/client/UCI.java
+++ b/src/main/java/net/andreinc/neatchess/client/UCI.java
@@ -62,7 +62,7 @@ public class UCI {
     }
 
     public void start(String cmd) {
-        var pb = new ProcessBuilder(cmd);
+        ProcessBuilder pb = new ProcessBuilder(cmd);
         try {
             this.process = pb.start();
             this.reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -121,7 +121,7 @@ public class UCI {
 
         CompletableFuture<UCIResponse<T>> processorFuture = command.handle((list, ex) -> {
             try {
-                var result = commandProcessor.apply(list);
+                T result = commandProcessor.apply(list);
                 return new UCIResponse<>(result, (UCIRuntimeException) ex);
             } catch (RuntimeException e) {
                 return new UCIResponse<T>(null, new UCIRuntimeException(e));

--- a/src/main/java/net/andreinc/neatchess/client/parser/AbstractParser.java
+++ b/src/main/java/net/andreinc/neatchess/client/parser/AbstractParser.java
@@ -22,7 +22,7 @@ public abstract class AbstractParser<T> {
     protected abstract T doParse(String line, Matcher matcher);
 
     public T parse(String line) {
-        var matcher = pattern.matcher(line);
+        Matcher matcher = pattern.matcher(line);
         if (matcher.matches()) {
             return doParse(line, matcher);
         }

--- a/src/main/java/net/andreinc/neatchess/client/parser/BestMoveParser.java
+++ b/src/main/java/net/andreinc/neatchess/client/parser/BestMoveParser.java
@@ -17,8 +17,8 @@ public class BestMoveParser extends AbstractParser<BestMove> {
 
     @Override
     protected BestMove doParse(String line, Matcher matcher) {
-        var curr = matcher.group(1);
-        var ponder = matcher.group(2);
+        String curr = matcher.group(1);
+        String ponder = matcher.group(2);
         return new BestMove(curr, ponder);
     }
 }

--- a/src/main/java/net/andreinc/neatchess/client/parser/EngineOptionParser.java
+++ b/src/main/java/net/andreinc/neatchess/client/parser/EngineOptionParser.java
@@ -26,21 +26,21 @@ public class EngineOptionParser extends AbstractParser<EngineOption> {
 
     @Override
     protected EngineOption doParse(String line, Matcher matcher) {
-        var optionName = matcher.group(1);
-        var optionType = matcher.group(2);
-        var defaultValue = matcher.group(4);
-        var payload  = matcher.group(5);
+        String optionName = matcher.group(1);
+        String optionType = matcher.group(2);
+        String defaultValue = matcher.group(4);
+        String payload  = matcher.group(5);
         switch (optionType) {
             case "button" : return new ButtonEngineOption(optionName, defaultValue);
             case "check" : return new CheckEngineOption(optionName, Boolean.parseBoolean(defaultValue));
             case "combo" : return new ComboEngineOption(optionName, defaultValue);
             case "spin" : {
-                var mmMatch = spinPattern.matcher(payload);
+                Matcher mmMatch = spinPattern.matcher(payload);
                 if (!mmMatch.matches()) {
                     throw new IllegalArgumentException("Invalid spin option:" + line);
                 }
-                var min = Integer.parseInt(mmMatch.group(1));
-                var max = Integer.parseInt(mmMatch.group(2));
+                int min = Integer.parseInt(mmMatch.group(1));
+                int max = Integer.parseInt(mmMatch.group(2));
                 return new SpinEngineOption(optionName, Integer.parseInt(defaultValue), min, max);
             }
             case "string" : return new StringEngineOption(optionName, defaultValue);

--- a/src/main/java/net/andreinc/neatchess/client/parser/InfoDepthParser.java
+++ b/src/main/java/net/andreinc/neatchess/client/parser/InfoDepthParser.java
@@ -29,11 +29,11 @@ public class InfoDepthParser extends AbstractParser<Move> {
         // group(5) => <num>
         // group(6) => move
         // group(7) => continuation
-        var depth = parseInt(matcher.group(1));
-        var multipv = parseInt(matcher.group(2));
-        var strength = matcher.group(3);
-        var move = matcher.group(6);
-        var continuation = matcher.group(7).split(" ");
+        int depth = parseInt(matcher.group(1));
+        int multipv = parseInt(matcher.group(2));
+        String strength = matcher.group(3);
+        String move = matcher.group(6);
+        String[] continuation = matcher.group(7).split(" ");
 
         return new Move(move, depth, new Strength(strength), multipv, continuation);
     }

--- a/src/main/java/net/andreinc/neatchess/client/processor/AnalysisProcessor.java
+++ b/src/main/java/net/andreinc/neatchess/client/processor/AnalysisProcessor.java
@@ -14,7 +14,7 @@ public class AnalysisProcessor extends UCICommandProcessor<Analysis> {
     protected static InfoDepthParser infoDepthParser = new InfoDepthParser();
     @Override
     public Analysis process(List<String> list) {
-        var map =
+        TreeMap<Integer, Move> map =
                 list.stream()
                     .filter(infoDepthParser::matches)
                     .map(infoDepthParser::parse)

--- a/src/main/java/net/andreinc/neatchess/client/processor/EngineInfoProcessor.java
+++ b/src/main/java/net/andreinc/neatchess/client/processor/EngineInfoProcessor.java
@@ -17,13 +17,13 @@ public class EngineInfoProcessor extends UCICommandProcessor<EngineInfo> {
 
     @Override
     public EngineInfo process(List<String> list) {
-        final var engineName =
+        final String engineName =
                 list.stream()
                         .filter(engineNameParser::matches)
                         .map(engineNameParser::parse)
                         .findFirst()
                         .orElse("<<Unknown>>");
-        final var options =
+        final java.util.Map<String, EngineOption> options =
                 list.stream()
                         .filter(engineOptionParser::matches)
                         .map(engineOptionParser::parse)


### PR DESCRIPTION
Remove usage of `var` to be compatible with java 8 so that I can use it properly

I am planning to both use this on a project that doesn't use maven, and also is at the java 8 language level. I plan to directly clone this repo to use as a dep.

I use java 8 because java 8 was the last java version to ship with javafx, and the only thing this repo has stopping is the usage of `var` so I went through and resolved all of them to an explicit type.

**NOTE** I did add a `.gitignore` as it was missing.